### PR TITLE
Adds ability to set timeouts for a knxdclient.KNXDConnection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ def handler(packet: knxdclient.ReceivedGroupAPDU) -> None:
     print("Received group telegram: {}".format(packet))
 
 async def main() -> None:
-    connection = knxdclient.KNXDConnection()
+    # Raises a TimeoutError after 30 seconds of not receiving any traffic. This argument is optional
+    connection = knxdclient.KNXDConnection(timeout=30.0) 
     connection.set_group_apdu_handler(handler)
     await connection.connect()
     # Connection was successful. Start receive loop:

--- a/knxdclient/client.py
+++ b/knxdclient/client.py
@@ -262,10 +262,8 @@ class KNXDConnection:
             while True:
                 try:
                     next_message_task = asyncio.create_task(queue.get())
-                    done, _pending = await asyncio.wait(
-                        [next_message_task, run_exited],
-                        return_when=asyncio.FIRST_COMPLETED
-                    )
+                    done, _pending = await asyncio.wait((next_message_task, run_exited),
+                                                        return_when=asyncio.FIRST_COMPLETED)
 
                     if run_exited in done:
                         raise ConnectionAbortedError("KNXDConnection was closed and is no longer sending messages")
@@ -304,7 +302,7 @@ class KNXDConnection:
             run_exited = asyncio.create_task(self._run_exited.wait())
             response_ready = asyncio.create_task(self._response_ready.wait())
 
-            done, _pending = await asyncio.wait([run_exited, response_ready], return_when=asyncio.FIRST_COMPLETED)
+            done, _pending = await asyncio.wait((run_exited, response_ready), return_when=asyncio.FIRST_COMPLETED)
 
             if run_exited in done:
                 response_ready.cancel()

--- a/knxdclient/client.py
+++ b/knxdclient/client.py
@@ -166,7 +166,8 @@ class KNXDConnection:
                     return
                 else:
                     raise ConnectionAbortedError("KNXd connection was closed with EOF unexpectedly.") from e
-            except (ConnectionError, asyncio.TimeoutError, asyncio.CancelledError) as error:
+            # From python 3.11 it will raise a stdlib TimeoutError instead of asyncio.TimeoutError
+            except (ConnectionError, TimeoutError, asyncio.TimeoutError, asyncio.CancelledError) as error:
                 # A connection, timeout or cancellation errors typically mean we cannot proceed further with this connection. 
                 # Thus we abort the receive loop execution with the exception.
                 logger.error(f"A connection, timeout or cancellation error has occurred. Aborting current connection. {error}")
@@ -246,7 +247,8 @@ class KNXDConnection:
                     yield await asyncio.wait_for(next_message_task, self._timeout)
                 else:
                     yield await queue.get()
-        except asyncio.TimeoutError:
+        # From Python 3.11 a stdlib TimeoutError is thrown instead
+        except (asyncio.TimeoutError, TimeoutError):
             logger.error(f"Timeout while awaiting for KNX messages")
         finally:
             self._group_apdu_handler = None

--- a/knxdclient/client.py
+++ b/knxdclient/client.py
@@ -117,9 +117,7 @@ class KNXDConnection:
         logger.info("Connecting to KNXd successful")
 
     async def _read_raw_knxpacket(self) -> bytes:
-        if self._reader is None or self._reader.at_eof():
-            raise ConnectionError("No connection to KNXD has been established yet or the previous connection's "
-                                  "StreamReader is at EOF")
+        assert self._reader is not None
         length = int.from_bytes(await self._reader.readexactly(2), byteorder='big')
         return await self._reader.readexactly(length)
 
@@ -143,6 +141,9 @@ class KNXDConnection:
         :raises ConnectionError: in case such an error occurs while reading
         :raises ConnectionError: when no connection has been established yet or the previous connection reached an EOF.
         """
+        if self._reader is None or self._reader.at_eof():
+            raise ConnectionError("No connection to KNXD has been established yet or the previous connection's "
+                                  "StreamReader is at EOF")
         logger.info("Entering KNXd client receive loop ...")
 
         while True:

--- a/knxdclient/client.py
+++ b/knxdclient/client.py
@@ -97,6 +97,8 @@ class KNXDConnection:
         """
         # Close previous connection gracefully if any
         if self._writer is not None:
+            # In case of a reconnect unset the _run_exited asyncio.Event
+            self._run_exited.clear()
             if not self._writer.is_closing():
                 self._writer.close()
             await self._writer.wait_closed()

--- a/knxdclient/client.py
+++ b/knxdclient/client.py
@@ -111,8 +111,10 @@ class KNXDConnection:
 
 
     async def _read_raw_knxpacket(self) -> bytes:
-        length = int.from_bytes(await self._reader.readexactly(2), byteorder='big')
-        return await self._reader.readexactly(length)
+        reader = self._reader
+        assert reader is not None
+        length = int.from_bytes(await reader.readexactly(2), byteorder='big')
+        return await reader.readexactly(length)
 
 
     async def run(self):

--- a/knxdclient/client.py
+++ b/knxdclient/client.py
@@ -153,7 +153,7 @@ class KNXDConnection:
                     data = await asyncio.wait_for(read_task, self._timeout)
                 else:
                     data = await self._read_raw_knxpacket()
-                    
+
                 packet = KNXDPacket.decode(data)
                 logger.debug("Received packet from KNXd: %s", packet)
                 if packet.type is KNXDPacketTypes.EIB_GROUP_PACKET:
@@ -173,15 +173,19 @@ class KNXDConnection:
                     raise ConnectionAbortedError("KNXd connection was closed with EOF unexpectedly.") from e
             # From python 3.11 it will raise a stdlib TimeoutError instead of asyncio.TimeoutError
             except (ConnectionError, TimeoutError, asyncio.TimeoutError, asyncio.CancelledError) as error:
-                # A connection, timeout or cancellation errors typically mean we cannot proceed further with this connection. 
+                # A connection, timeout or cancellation errors
+                # typically mean we cannot proceed further with this connection.
                 # Thus we abort the receive loop execution with the exception.
-                logger.error(f"A connection, timeout or cancellation error has occurred. Aborting current connection. {error}")
+                logger.error(' '.join([
+                    "A connection, timeout or cancellation error has occurred.",
+                    f"Aborting current connection. {error}"
+                ]))
                 self._run_exited.set()
                 raise
             except Exception as e:
                 logger.error("Error while receiving KNX packets:", exc_info=e)
                 self._run_exited.set()
-                raise  
+                raise
 
     async def stop(self):
         """
@@ -253,13 +257,13 @@ class KNXDConnection:
             while True:
                 next_message_task = asyncio.create_task(queue.get())
                 done, _pending = await asyncio.wait(
-                    [next_message_task, run_exited], 
+                    [next_message_task, run_exited],
                     return_when=asyncio.FIRST_COMPLETED
                 )
-                
+
                 if run_exited in done:
                     raise ConnectionAbortedError("KNXDConnection was closed and is no longer sending messages")
-                
+
                 yield next_message_task.result()
         except Exception as ex:
             logger.error(ex)
@@ -286,7 +290,7 @@ class KNXDConnection:
             self._response_ready.clear()
             await self._send_eibd_packet(KNXDPacket(KNXDPacketTypes.EIB_OPEN_GROUPCON,
                                                     bytes([0, 0xff if write_only else 0, 0])))
-            
+
             run_exited = asyncio.create_task(self._run_exited.wait())
             response_ready = asyncio.create_task(self._response_ready.wait())
 

--- a/knxdclient/client.py
+++ b/knxdclient/client.py
@@ -182,10 +182,8 @@ class KNXDConnection:
                 # A connection, timeout or cancellation errors
                 # typically mean we cannot proceed further with this connection.
                 # Thus we abort the receive loop execution with the exception.
-                logger.error(' '.join([
-                    "A connection, timeout or cancellation error has occurred.",
-                    f"Aborting current connection. {error}"
-                ]))
+                logger.error("A connection, timeout or cancellation error has occurred. "
+                             "Aborting current connection: %s", error)
                 self._run_exited.set()
                 raise
             except Exception as e:

--- a/knxdclient/client.py
+++ b/knxdclient/client.py
@@ -108,9 +108,8 @@ class KNXDConnection:
         logger.info("Connecting to KNXd successful")
 
 
-    async def _read_raw_knxpacket(self):
+    async def _read_raw_knxpacket(self) -> bytes:
         length = int.from_bytes(await self._reader.readexactly(2), byteorder='big')
-        # data is "bytes"
         return await self._reader.readexactly(length)
         
 

--- a/knxdclient/client.py
+++ b/knxdclient/client.py
@@ -116,14 +116,12 @@ class KNXDConnection:
             self._reader, self._writer = await asyncio.open_connection(host=host, port=port)
         logger.info("Connecting to KNXd successful")
 
-
     async def _read_raw_knxpacket(self) -> bytes:
         if self._reader is None or self._reader.at_eof():
             raise ConnectionError("No connection to KNXD has been established yet or the previous connection's "
                                   "StreamReader is at EOF")
         length = int.from_bytes(await self._reader.readexactly(2), byteorder='big')
         return await self._reader.readexactly(length)
-
 
     async def run(self):
         """
@@ -183,8 +181,7 @@ class KNXDConnection:
             except Exception as e:
                 logger.error("Error while receiving KNX packets:", exc_info=e)
                 self._run_exited.set()
-                raise
-                
+                raise  
 
     async def stop(self):
         """

--- a/knxdclient/client.py
+++ b/knxdclient/client.py
@@ -113,10 +113,11 @@ class KNXDConnection:
 
 
     async def _read_raw_knxpacket(self) -> bytes:
-        reader = self._reader
-        assert reader is not None
-        length = int.from_bytes(await reader.readexactly(2), byteorder='big')
-        return await reader.readexactly(length)
+        if self._reader is None or self._reader.at_eof():
+            raise ConnectionError("No connection to KNXD has been established yet or the previous connection's "
+                                  "StreamReader is at EOF")
+        length = int.from_bytes(await self._reader.readexactly(2), byteorder='big')
+        return await self._reader.readexactly(length)
 
 
     async def run(self):
@@ -140,10 +141,6 @@ class KNXDConnection:
         :raises ConnectionError: when no connection has been established yet or the previous connection reached an EOF.
         """
         logger.info("Entering KNXd client receive loop ...")
-
-        if self._reader is None or self._reader.at_eof():
-            raise ConnectionError("No connection to KNXD has been established yet or the previous connection's "
-                                  "StreamReader is at EOF")
 
         while True:
             try:

--- a/knxdclient/client.py
+++ b/knxdclient/client.py
@@ -144,7 +144,7 @@ class KNXDConnection:
         while True:
             try:
                 data = None
-                if self._timeout:
+                if self._timeout is not None:
                     read_task = self._read_raw_knxpacket()
                     data = await asyncio.wait_for(read_task, self._timeout)
                 else:

--- a/knxdclient/client.py
+++ b/knxdclient/client.py
@@ -247,15 +247,15 @@ class KNXDConnection:
         queue: asyncio.Queue[ReceivedGroupAPDU] = asyncio.Queue()
         self._group_apdu_handler = queue.put_nowait
         try:
-            wait_for_exit_task = asyncio.create_task(self._run_exited.wait())
+            run_exited = asyncio.create_task(self._run_exited.wait())
             while True:
                 next_message_task = asyncio.create_task(queue.get())
                 done, _pending = await asyncio.wait(
-                    [next_message_task, wait_for_exit_task], 
+                    [next_message_task, run_exited], 
                     return_when=asyncio.FIRST_COMPLETED
                 )
                 
-                if wait_for_exit_task in done:
+                if run_exited in done:
                     raise ConnectionAbortedError("KNXDConnection was closed and is no longer sending messages")
                 
                 yield next_message_task.result()

--- a/knxdclient/client.py
+++ b/knxdclient/client.py
@@ -62,6 +62,11 @@ class KNXDConnection:
         await run_task
     """
     def __init__(self, timeout: Optional[float] = None):
+        """
+        Parameters:
+        - timeout (float, optional): Maximum time allowed for the connection operation to complete, in seconds.
+        Defaults to None.
+        """
         self._group_apdu_handler: Optional[Callable[[ReceivedGroupAPDU], Any]] = None
         self.closing = False
         self._current_response: Optional[KNXDPacket] = None

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -230,6 +230,7 @@ class KNXDClientTest(unittest.TestCase):
                 await run_task
 
 
+@unittest.skipIf(shutil.which("knxd") is None, "knxd is not available in PATH")
 class KNXDClientTCPTest(unittest.TestCase):
     def setUp(self) -> None:
         self.knxd_process = subprocess.Popen(["knxd", "--listen-tcp=16720", "-e", "0.5.1", "-E",

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -148,7 +148,7 @@ class KNXDClientTest(unittest.TestCase):
             await connection.open_group_socket()
         finally:
             await connection.stop()
-            with suppress(asyncio.CancelledError, ConnectionAbortedError):
+            with suppress(asyncio.CancelledError):
                 await run_task
 
     @async_test

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -7,6 +7,7 @@ import unittest
 import unittest.mock
 import time
 from contextlib import suppress
+import sys
 
 import knxdclient
 from ._helper import async_test
@@ -254,3 +255,28 @@ class KNXDClientTCPTest(unittest.TestCase):
             await connection.stop()
             with suppress(asyncio.CancelledError):
                 await run_task
+
+
+class KNXDClientTimeoutTest(unittest.TestCase):
+    @async_test
+    async def test_timeout(self) -> None:
+        # Create TCP server
+        async def client_handler(reader, writer):
+            # We never respond anything, so the client should run into timeout
+            await reader.read(-1)
+        server = await asyncio.start_server(client_handler, host="127.0.0.1", port=16720)
+
+        try:
+            # Setup connection and receive loop task
+            connection = knxdclient.KNXDConnection(timeout=1)
+            await connection.connect(host="127.0.0.1", port=16720)
+            run_task = asyncio.create_task(connection.run())
+
+            with self.assertRaises(ConnectionAbortedError):
+                await connection.open_group_socket()
+
+            with self.assertRaises(TimeoutError if sys.version_info >= (3, 11) else asyncio.TimeoutError):
+                await run_task
+        finally:
+            server.close()
+            await server.wait_closed()

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -148,7 +148,7 @@ class KNXDClientTest(unittest.TestCase):
             await connection.open_group_socket()
         finally:
             await connection.stop()
-            with suppress(asyncio.CancelledError):
+            with suppress(asyncio.CancelledError, ConnectionAbortedError):
                 await run_task
 
     @async_test


### PR DESCRIPTION
First of all, thank you for creating this library. It's nice and easy to use.

## Issue
I have a server running `knxd` that reboots once a day and I've noticed that if one uses `iterate_group_telegrams` and `knxd` reboots it leaves the coroutine hanging; awaiting for a message that will never come since the connection was dropped. This is caused because there were no timeouts in place.

## Suggested fix
I've added an optional parameter to the class `KNXDConnection` that can be used as a second argument to `asyncio.wait_for` and it is used in places where we are reading from `knxd`. The timeout errors will allow us to break out of the `while True` polling statements.

If the `timeout` is `None` old behavior is used instead.

Thank you for taking a look at this.

Miquel