### PR TITLE
Add DPT232

### DIFF
--- a/knxdclient/encoding.py
+++ b/knxdclient/encoding.py
@@ -279,6 +279,6 @@ def decode_value(value: EncodedData, t: KNXDPT) -> Any:
         # The raw int val is returned. The User code must construct the correct Enum type if required.
         return val[0]
     elif t is KNXDPT.COLOUR_RGB:
-        return f'#{(val[2] + (val[1] << 8) + (val[0] << 16)):X}'
+        return f'{(val[2] + (val[1] << 8) + (val[0] << 16)):X}'
     else:
         raise NotImplementedError()

--- a/knxdclient/encoding.py
+++ b/knxdclient/encoding.py
@@ -213,7 +213,11 @@ def encode_value(value: Any, t: KNXDPT) -> EncodedData:
     elif t is KNXDPT.VARSTRING:
         return val.encode('iso-8859-1') + b'\0'
     elif t is KNXDPT.COLOUR_RGB:
-        # TODO: validation checks
+        if len(val) != 3:
+            raise ValueError(f"KNX DPT 232 requires a three-byte tuple. Received {len(val)}")
+        for this_byte in val:
+            if not 0 <= this_byte <= 255:
+                raise ValueError(f"KNX DPT 232 colours must be 0-255. Received {this_byte}")
         return bytes(val)
     else:
         raise NotImplementedError()

--- a/knxdclient/encoding.py
+++ b/knxdclient/encoding.py
@@ -47,6 +47,7 @@ class KNXDPT(enum.Enum):
     DATE_TIME = 19
     ENUM8 = 20
     VARSTRING = 24
+    COLOUR_RGB = 232
 
 
 class KNXTime(NamedTuple):
@@ -81,6 +82,7 @@ DPT_ENCODING: Dict[KNXDPT, Type[EncodedData]] = {
     KNXDPT.DATE_TIME: bytes,
     KNXDPT.ENUM8: bytes,
     KNXDPT.VARSTRING: bytes,
+    KNXDPT.COLOUR_RGB: bytes,
 }
 
 DPT_PYTHON_REPRESENTATION: Dict[KNXDPT, Union[type, Tuple[type, ...]]] = {
@@ -104,6 +106,7 @@ DPT_PYTHON_REPRESENTATION: Dict[KNXDPT, Union[type, Tuple[type, ...]]] = {
     KNXDPT.DATE_TIME: (datetime.datetime, datetime.date, datetime.time),
     KNXDPT.ENUM8: (int, enum.Enum),
     KNXDPT.VARSTRING: str,
+    KNXDPT.COLOUR_RGB: bytes,
 }
 
 
@@ -209,6 +212,8 @@ def encode_value(value: Any, t: KNXDPT) -> EncodedData:
         return bytes([val])
     elif t is KNXDPT.VARSTRING:
         return val.encode('iso-8859-1') + b'\0'
+    elif t is KNXDPT.COLOUR_RGB:
+        return bytes([val]) # TODO
     else:
         raise NotImplementedError()
 
@@ -273,5 +278,7 @@ def decode_value(value: EncodedData, t: KNXDPT) -> Any:
     elif t is KNXDPT.ENUM8:
         # The raw int val is returned. The User code must construct the correct Enum type if required.
         return val[0]
+    elif t is KNXDPT.COLOUR_RGB:
+        return f'#{(val[2] + (val[1] << 8) + (val[0] << 16)):X}'
     else:
         raise NotImplementedError()

--- a/knxdclient/encoding.py
+++ b/knxdclient/encoding.py
@@ -106,7 +106,7 @@ DPT_PYTHON_REPRESENTATION: Dict[KNXDPT, Union[type, Tuple[type, ...]]] = {
     KNXDPT.DATE_TIME: (datetime.datetime, datetime.date, datetime.time),
     KNXDPT.ENUM8: (int, enum.Enum),
     KNXDPT.VARSTRING: str,
-    KNXDPT.COLOUR_RGB: bytes,
+    KNXDPT.COLOUR_RGB: (int, int, int),
 }
 
 
@@ -213,7 +213,8 @@ def encode_value(value: Any, t: KNXDPT) -> EncodedData:
     elif t is KNXDPT.VARSTRING:
         return val.encode('iso-8859-1') + b'\0'
     elif t is KNXDPT.COLOUR_RGB:
-        return bytes([val[0] , val[1] , val[2]])
+        # TODO: validation checks
+        return bytes(val)
     else:
         raise NotImplementedError()
 
@@ -279,6 +280,6 @@ def decode_value(value: EncodedData, t: KNXDPT) -> Any:
         # The raw int val is returned. The User code must construct the correct Enum type if required.
         return val[0]
     elif t is KNXDPT.COLOUR_RGB:
-        return f'{(val[2] + (val[1] << 8) + (val[0] << 16)):X}'
+        return tuple(val)
     else:
         raise NotImplementedError()

--- a/knxdclient/encoding.py
+++ b/knxdclient/encoding.py
@@ -106,7 +106,7 @@ DPT_PYTHON_REPRESENTATION: Dict[KNXDPT, Union[type, Tuple[type, ...]]] = {
     KNXDPT.DATE_TIME: (datetime.datetime, datetime.date, datetime.time),
     KNXDPT.ENUM8: (int, enum.Enum),
     KNXDPT.VARSTRING: str,
-    KNXDPT.COLOUR_RGB: (int, int, int),
+    KNXDPT.COLOUR_RGB: tuple,
 }
 
 

--- a/knxdclient/encoding.py
+++ b/knxdclient/encoding.py
@@ -215,9 +215,6 @@ def encode_value(value: Any, t: KNXDPT) -> EncodedData:
     elif t is KNXDPT.COLOUR_RGB:
         if len(val) != 3:
             raise ValueError(f"KNX DPT 232 requires a three-byte tuple. Received {len(val)}")
-        for this_byte in val:
-            if not 0 <= this_byte <= 255:
-                raise ValueError(f"KNX DPT 232 colours must be 0-255. Received {this_byte}")
         return bytes(val)
     else:
         raise NotImplementedError()

--- a/knxdclient/encoding.py
+++ b/knxdclient/encoding.py
@@ -213,7 +213,7 @@ def encode_value(value: Any, t: KNXDPT) -> EncodedData:
     elif t is KNXDPT.VARSTRING:
         return val.encode('iso-8859-1') + b'\0'
     elif t is KNXDPT.COLOUR_RGB:
-        return bytes([val]) # TODO
+        return bytes([val[0] , val[1] , val[2]])
     else:
         raise NotImplementedError()
 

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -273,10 +273,10 @@ class MQTTClientTest(unittest.TestCase):
 
     def test_dpt232_conversion(self) -> None:
         self.assertEqual(bytes([0x10, 0xCC, 0x0A]),
-                         knxdclient.encode_value(0x10CC0A, knxdclient.KNXDPT.COLOUR_RGB))
+                         knxdclient.encode_value(bytes([0x10, 0xCC, 0x0A]), knxdclient.KNXDPT.COLOUR_RGB))
         self.assertEqual(bytes([127, 00, 32]),
-                         knxdclient.encode_value(0x7F0020, knxdclient.KNXDPT.COLOUR_RGB))
-        self.assertEqual(0x801B10,
+                         knxdclient.encode_value(bytes([0x7F, 0x00, 0x20]), knxdclient.KNXDPT.COLOUR_RGB))
+        self.assertEqual(f'{0x801B10:X}',
                          knxdclient.decode_value(bytes([0x80, 0x1B, 0x10]), knxdclient.KNXDPT.COLOUR_RGB))
-        self.assertEqual(0x123456,
-                         knxdclient.decode_value(bytes(0x12, 0x34, 0x56), knxdclient.KNXDPT.COLOUR_RGB))
+        self.assertEqual(f'{0x123456:X}',
+                         knxdclient.decode_value(bytes([0x12, 0x34, 0x56]), knxdclient.KNXDPT.COLOUR_RGB))

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -275,3 +275,7 @@ class MQTTClientTest(unittest.TestCase):
         self.assertEqual((0x12, 0x34, 0x56),
                          knxdclient.decode_value(knxdclient.encode_value((0x12, 0x34, 0x56), knxdclient.KNXDPT.COLOUR_RGB),
                                                  knxdclient.KNXDPT.COLOUR_RGB))
+        self.assertEqual(bytes([0x7f, 0x00, 0x20]),
+                         knxdclient.encode_value((0x7f, 0x00, 0x20), knxdclient.KNXDPT.COLOUR_RGB))
+        self.assertEqual((0x10, 0xcc, 0x0a),
+                         knxdclient.decode_value(bytes([0x10, 0xcc, 0x0a]), knxdclient.KNXDPT.COLOUR_RGB))

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -270,3 +270,13 @@ class MQTTClientTest(unittest.TestCase):
         self.assertEqual(bytes([2]), knxdclient.encode_value(HAVCMode.Standby, knxdclient.KNXDPT.ENUM8))
         self.assertEqual(bytes([2]), knxdclient.encode_value(2, knxdclient.KNXDPT.ENUM8))
         self.assertEqual(2, knxdclient.decode_value(bytes([2]), knxdclient.KNXDPT.ENUM8))
+
+    def test_dpt232_conversion(self) -> None:
+        self.assertEqual(bytes([0x10, 0xCC, 0x0A]),
+                         knxdclient.encode_value(0x10CC0A, knxdclient.KNXDPT.COLOUR_RGB))
+        self.assertEqual(bytes([127, 00, 32]),
+                         knxdclient.encode_value(0x7F0020, knxdclient.KNXDPT.COLOUR_RGB))
+        self.assertEqual(0x801B10,
+                         knxdclient.decode_value(bytes([0x80, 0x1B, 0x10]), knxdclient.KNXDPT.COLOUR_RGB))
+        self.assertEqual(0x123456,
+                         knxdclient.decode_value(bytes(0x12, 0x34, 0x56), knxdclient.KNXDPT.COLOUR_RGB))

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -273,8 +273,9 @@ class MQTTClientTest(unittest.TestCase):
 
     def test_dpt232_conversion(self) -> None:
         self.assertEqual((0x12, 0x34, 0x56),
-                         knxdclient.decode_value(knxdclient.encode_value((0x12, 0x34, 0x56), knxdclient.KNXDPT.COLOUR_RGB),
-                                                 knxdclient.KNXDPT.COLOUR_RGB))
+                         knxdclient.decode_value(
+                             knxdclient.encode_value((0x12, 0x34, 0x56), knxdclient.KNXDPT.COLOUR_RGB),
+                             knxdclient.KNXDPT.COLOUR_RGB))
         self.assertEqual(bytes([0x7f, 0x00, 0x20]),
                          knxdclient.encode_value((0x7f, 0x00, 0x20), knxdclient.KNXDPT.COLOUR_RGB))
         self.assertEqual((0x10, 0xcc, 0x0a),

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -272,11 +272,6 @@ class MQTTClientTest(unittest.TestCase):
         self.assertEqual(2, knxdclient.decode_value(bytes([2]), knxdclient.KNXDPT.ENUM8))
 
     def test_dpt232_conversion(self) -> None:
-        self.assertEqual(bytes([0x10, 0xCC, 0x0A]),
-                         knxdclient.encode_value(bytes([0x10, 0xCC, 0x0A]), knxdclient.KNXDPT.COLOUR_RGB))
-        self.assertEqual(bytes([127, 00, 32]),
-                         knxdclient.encode_value(bytes([0x7F, 0x00, 0x20]), knxdclient.KNXDPT.COLOUR_RGB))
-        self.assertEqual(f'{0x801B10:X}',
-                         knxdclient.decode_value(bytes([0x80, 0x1B, 0x10]), knxdclient.KNXDPT.COLOUR_RGB))
-        self.assertEqual(f'{0x123456:X}',
-                         knxdclient.decode_value(bytes([0x12, 0x34, 0x56]), knxdclient.KNXDPT.COLOUR_RGB))
+        self.assertEqual((0x12, 0x34, 0x56),
+                         knxdclient.decode_value(knxdclient.encode_value((0x12, 0x34, 0x56), knxdclient.KNXDPT.COLOUR_RGB),
+                                                 knxdclient.KNXDPT.COLOUR_RGB))


### PR DESCRIPTION
Hi Michael,

This PR adds encoding and decoding of DPT 232.

I've never written unit tests before, but I think what I've done is valid:

```
pi@captureKNX-Tijl:~/tests/knxdclient $ python3 -m unittest
..Send request
Send request
.Send request
Send request
..Error while waiting for next packet from KNXd: TimeoutError(). Exiting from receive loop.
........................
----------------------------------------------------------------------
Ran 29 tests in 2.922s

OK
pi@captureKNX-Tijl:~/tests/knxdclient $
```

Let me know if anything's not quite right and I'll amend as required.

If you're OK with it I'll add more DPTs as users of my [captureKNX](https://github.com/greiginsydney/captureKNX) bring them to my attention??

Thanks.


\- Greig.