### PR TITLE
Added DPT 29 (INT64)

### DIFF
--- a/knxdclient/encoding.py
+++ b/knxdclient/encoding.py
@@ -47,6 +47,7 @@ class KNXDPT(enum.Enum):
     DATE_TIME = 19
     ENUM8 = 20
     VARSTRING = 24
+    INT64 = 29
     COLOUR_RGB = 232
 
 
@@ -82,6 +83,7 @@ DPT_ENCODING: Dict[KNXDPT, Type[EncodedData]] = {
     KNXDPT.DATE_TIME: bytes,
     KNXDPT.ENUM8: bytes,
     KNXDPT.VARSTRING: bytes,
+    KNXDPT.INT64: bytes,
     KNXDPT.COLOUR_RGB: bytes,
 }
 
@@ -106,6 +108,7 @@ DPT_PYTHON_REPRESENTATION: Dict[KNXDPT, Union[type, Tuple[type, ...]]] = {
     KNXDPT.DATE_TIME: (datetime.datetime, datetime.date, datetime.time),
     KNXDPT.ENUM8: (int, enum.Enum),
     KNXDPT.VARSTRING: str,
+    KNXDPT.INT64: int,
     KNXDPT.COLOUR_RGB: tuple,
 }
 
@@ -212,6 +215,8 @@ def encode_value(value: Any, t: KNXDPT) -> EncodedData:
         return bytes([val])
     elif t is KNXDPT.VARSTRING:
         return val.encode('iso-8859-1') + b'\0'
+    elif t is KNXDPT.INT64:
+        return struct.pack('>q', val)
     elif t is KNXDPT.COLOUR_RGB:
         if len(val) != 3:
             raise ValueError(f"KNX DPT 232 requires a three-byte tuple. Received {len(val)}")
@@ -280,6 +285,8 @@ def decode_value(value: EncodedData, t: KNXDPT) -> Any:
     elif t is KNXDPT.ENUM8:
         # The raw int val is returned. The User code must construct the correct Enum type if required.
         return val[0]
+    elif t is KNXDPT.INT64:
+        return struct.unpack('>q', val)[0]
     elif t is KNXDPT.COLOUR_RGB:
         return tuple(val)
     else:

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -271,6 +271,16 @@ class MQTTClientTest(unittest.TestCase):
         self.assertEqual(bytes([2]), knxdclient.encode_value(2, knxdclient.KNXDPT.ENUM8))
         self.assertEqual(2, knxdclient.decode_value(bytes([2]), knxdclient.KNXDPT.ENUM8))
 
+    def test_dpt29_conversion(self) -> None:
+        self.assertEqual(bytes([0xff, 0xff, 0xff, 0xff, 0xf8, 0xa4, 0x32, 0xeb]),
+                         knxdclient.encode_value(-123456789, knxdclient.KNXDPT.INT64))
+        self.assertEqual(bytes([0x00, 0x00, 0x00, 0x0b, 0xad, 0xc0, 0xff, 0xee]),
+                         knxdclient.encode_value(0xbadc0ffee, knxdclient.KNXDPT.INT64))
+        self.assertEqual(-123456789,
+                         knxdclient.decode_value(bytes([0xff, 0xff, 0xff, 0xff, 0xf8, 0xa4, 0x32, 0xeb]), knxdclient.KNXDPT.INT64))
+        self.assertEqual(0xbadc0ffee,
+                         knxdclient.decode_value(bytes([0x00, 0x00, 0x00, 0x0b, 0xad, 0xc0, 0xff, 0xee]), knxdclient.KNXDPT.INT64))
+
     def test_dpt232_conversion(self) -> None:
         self.assertEqual((0x12, 0x34, 0x56),
                          knxdclient.decode_value(

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -277,10 +277,10 @@ class MQTTClientTest(unittest.TestCase):
         self.assertEqual(bytes([0x00, 0x00, 0x00, 0x0b, 0xad, 0xc0, 0xff, 0xee]),
                          knxdclient.encode_value(0xbadc0ffee, knxdclient.KNXDPT.INT64))
         self.assertEqual(-123456789,
-                         knxdclient.decode_value(bytes([0xff, 0xff, 0xff, 0xff, 0xf8, 0xa4, 0x32, 0xeb]), 
+                         knxdclient.decode_value(bytes([0xff, 0xff, 0xff, 0xff, 0xf8, 0xa4, 0x32, 0xeb]),
                                                  knxdclient.KNXDPT.INT64))
         self.assertEqual(0xbadc0ffee,
-                         knxdclient.decode_value(bytes([0x00, 0x00, 0x00, 0x0b, 0xad, 0xc0, 0xff, 0xee]), 
+                         knxdclient.decode_value(bytes([0x00, 0x00, 0x00, 0x0b, 0xad, 0xc0, 0xff, 0xee]),
                                                  knxdclient.KNXDPT.INT64))
 
     def test_dpt232_conversion(self) -> None:

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -277,9 +277,11 @@ class MQTTClientTest(unittest.TestCase):
         self.assertEqual(bytes([0x00, 0x00, 0x00, 0x0b, 0xad, 0xc0, 0xff, 0xee]),
                          knxdclient.encode_value(0xbadc0ffee, knxdclient.KNXDPT.INT64))
         self.assertEqual(-123456789,
-                         knxdclient.decode_value(bytes([0xff, 0xff, 0xff, 0xff, 0xf8, 0xa4, 0x32, 0xeb]), knxdclient.KNXDPT.INT64))
+                         knxdclient.decode_value(bytes([0xff, 0xff, 0xff, 0xff, 0xf8, 0xa4, 0x32, 0xeb]), 
+                                                 knxdclient.KNXDPT.INT64))
         self.assertEqual(0xbadc0ffee,
-                         knxdclient.decode_value(bytes([0x00, 0x00, 0x00, 0x0b, 0xad, 0xc0, 0xff, 0xee]), knxdclient.KNXDPT.INT64))
+                         knxdclient.decode_value(bytes([0x00, 0x00, 0x00, 0x0b, 0xad, 0xc0, 0xff, 0xee]), 
+                                                 knxdclient.KNXDPT.INT64))
 
     def test_dpt232_conversion(self) -> None:
         self.assertEqual((0x12, 0x34, 0x56),


### PR DESCRIPTION

This is a copy of the existing DPT 13 (INT32) just with twice as many bytes in the test.

Is it OK like this or do you prefer to see a round-trip test included?